### PR TITLE
Bfloat16

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,4 +58,5 @@ const EXAMPLES_DIR = "examples/";
 const EXAMPLE_NAMES = &.{
     "basic",
     "benchmark",
+    "bfloat16",
 };

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 
-const T = i32;
-const Tensor = @import("zensor").Tensor(T);
+const zensor = @import("zensor");
+const dtype = zensor.dtypes.float32;
+const Tensor = @import("zensor").Tensor(dtype);
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -11,7 +12,7 @@ pub fn main() !void {
     defer A.deinit();
     std.debug.print("{}\n", .{A});
 
-    const slice: []const []const T = &.{
+    const slice: []const []const f32 = &.{
         &.{ -3, -2, -1 },
     };
     var B = try Tensor.fromOwnedSlice(allocator, slice);

--- a/examples/benchmark.zig
+++ b/examples/benchmark.zig
@@ -5,8 +5,11 @@ const debug = std.debug;
 const assert = debug.assert;
 const print = debug.print;
 
-const T = i32;
-const Tensor = @import("zensor").Tensor(T);
+const zensor = @import("zensor");
+const dtypes = zensor.dtypes;
+const dtype = dtypes.float32;
+const T = dtype.kind;
+const Tensor = @import("zensor").Tensor;
 
 const TRIALS = 1000;
 const SIZE = 512;
@@ -24,8 +27,8 @@ fn trial(allocator: Allocator) !void {
     print("\tNumber of Trials: {}\n", .{TRIALS});
 
     var A = switch (@typeInfo(T)) {
-        .Float => try Tensor.rand(allocator, .{ SIZE, SIZE }),
-        .Int => try Tensor.randInt(allocator, .{ SIZE, SIZE }, 0, 10),
+        .Float => try Tensor.rand(allocator, .{ SIZE, SIZE }, dtype),
+        .Int => try Tensor.randInt(allocator, .{ SIZE, SIZE }, 0, 10, dtype),
         else => unreachable,
     };
     defer A.deinit();

--- a/examples/benchmark.zig
+++ b/examples/benchmark.zig
@@ -9,7 +9,7 @@ const zensor = @import("zensor");
 const dtypes = zensor.dtypes;
 const dtype = dtypes.float32;
 const T = dtype.kind;
-const Tensor = @import("zensor").Tensor;
+const Tensor = @import("zensor").Tensor(dtype);
 
 const TRIALS = 1000;
 const SIZE = 512;
@@ -27,8 +27,8 @@ fn trial(allocator: Allocator) !void {
     print("\tNumber of Trials: {}\n", .{TRIALS});
 
     var A = switch (@typeInfo(T)) {
-        .Float => try Tensor.rand(allocator, .{ SIZE, SIZE }, dtype),
-        .Int => try Tensor.randInt(allocator, .{ SIZE, SIZE }, 0, 10, dtype),
+        .Float => try Tensor.rand(allocator, .{ SIZE, SIZE }),
+        .Int => try Tensor.randInt(allocator, .{ SIZE, SIZE }, 0, 10),
         else => unreachable,
     };
     defer A.deinit();

--- a/examples/bfloat16.zig
+++ b/examples/bfloat16.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+const zensor = @import("zensor");
+const dtypes = zensor.dtypes;
+const Tensor = @import("zensor").Tensor;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    const dtype = dtypes.bfloat16;
+
+    var A = try Tensor(dtype).full(allocator, .{ 4, 3 }, 42.0);
+    defer A.deinit();
+    std.debug.print("{}\n", .{A});
+
+    var B = try Tensor(dtype).full(allocator, .{ 4, 3 }, 6.9);
+    defer B.deinit();
+    std.debug.print("{}\n", .{B});
+
+    var C = try A.add(&B);
+    defer C.deinit();
+    std.debug.print("{}\n", .{C});
+}


### PR DESCRIPTION
This adds initialization for bfloat16. Operations will be added in a separate PR. The reason for this is that bfloat16 requires a separate approach for ops as it is not a builtin type so add, mul, etc aren't supported.

I will first work on a simple compute graph implementation so that the Tensor struct does not have to be aware of all datatypes and cater to them.